### PR TITLE
build.zig: use b.path(..) instead of LazyPath anon structs.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,14 +4,14 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const copyFiles = b.addWriteFiles();
-    _ = copyFiles.addCopyFile(.{ .path = "config.h.generic" }, "config.h");
-    _ = copyFiles.addCopyFile(.{ .path = "pcre.h.generic" }, "pcre.h");
+    _ = copyFiles.addCopyFile(b.path("config.h.generic"), "config.h");
+    _ = copyFiles.addCopyFile(b.path("pcre.h.generic"), "pcre.h");
     const lib = b.addStaticLibrary(.{
         .name = b.fmt("pcre", .{}),
         .target = target,
         .optimize = optimize,
     });
-    lib.addIncludePath(.{ .path = b.pathFromRoot(".") });
+    lib.addIncludePath(b.path("."));
     lib.addIncludePath(copyFiles.getDirectory());
     lib.linkLibC();
     lib.installHeader(b.path("pcre.h"), "pcre.h");

--- a/build.zig
+++ b/build.zig
@@ -3,16 +3,12 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const copyFiles = b.addWriteFiles();
-    _ = copyFiles.addCopyFile(b.path("config.h.generic"), "config.h");
-    _ = copyFiles.addCopyFile(b.path("pcre.h.generic"), "pcre.h");
     const lib = b.addStaticLibrary(.{
         .name = b.fmt("pcre", .{}),
         .target = target,
         .optimize = optimize,
     });
     lib.addIncludePath(b.path("."));
-    lib.addIncludePath(copyFiles.getDirectory());
     lib.linkLibC();
     lib.installHeader(b.path("pcre.h"), "pcre.h");
 

--- a/config.h
+++ b/config.h
@@ -209,7 +209,7 @@ sure both macros are undefined; an emulation function will then be used. */
    steam using pcre_recurse_malloc() to obtain memory from the heap. For more
    detail, see the comments and other stuff just above the match() function.
    */
-/* #undef NO_RECURSE */
+#define NO_RECURSE /**/
 
 /* Name of package */
 #define PACKAGE "pcre"


### PR DESCRIPTION
This lets the target PR (https://github.com/nektro/pcre-8.45/pull/2) build on both 0.12 and 0.13.